### PR TITLE
Fix compile with Qt 6.8

### DIFF
--- a/qsql_sqlite.cpp
+++ b/qsql_sqlite.cpp
@@ -39,7 +39,7 @@ Q_DECLARE_METATYPE(sqlite3_stmt*)
 
 QT_BEGIN_NAMESPACE
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
     Q_LOGGING_CATEGORY(lcSqlite, "qt.sql.sqlite")
 #else
     Q_STATIC_LOGGING_CATEGORY(lcSqlite, "qt.sql.sqlite")


### PR DESCRIPTION
Q_STATIC_LOGGING_CATEGORY is only available in Qt6.9 so don't try to use it with Qt6.8